### PR TITLE
Support VOMS authentication with Keystone V3

### DIFF
--- a/pymodule/helpers.py
+++ b/pymodule/helpers.py
@@ -83,10 +83,10 @@ def get_keystone_v3_token(unscoped_token_getter, host, usertoken, capath, timeou
                                     data=None, timeout=timeout, verify=False)
             response.raise_for_status()
             projects = response.json()['projects']
-            project = ''
+            project = {}
             for p in projects:
                 if 'ops' in p['name']:
-                    project = p['id']
+                    project = p
                     break
             else:
                 # just take one

--- a/src/novaprobe.py
+++ b/src/novaprobe.py
@@ -142,7 +142,7 @@ def main():
             except helpers.AuthenticationException as e:
                 # no more authentication methods to try, fail here
                 print 'Unable to authenticate with VOMS + Keystone V3: %s' % e
-            # finally try with certificate v2
+            # try with certificate v2
             try:
                 ks_token, tenant, last_response = helpers.get_keystone_token_x509_v2(argholder.endpoint,
                                                                                      argholder.cert,

--- a/src/novaprobe.py
+++ b/src/novaprobe.py
@@ -122,22 +122,32 @@ def main():
         access_token = access_file.read().rstrip("\n")
         access_file.close()
         try:
-            ks_token, tenant, last_response = helpers.get_keystone_oidc_token(argholder.endpoint,
-                                                                              access_token,
-                                                                              argholder.capath,
-                                                                              argholder.timeout)
+            ks_token, tenant, last_response = helpers.get_keystone_token_oidc_v3(argholder.endpoint,
+                                                                                 access_token,
+                                                                                 argholder.capath,
+                                                                                 argholder.timeout)
             tenant_id, nova_url = get_info_v3(tenant, last_response)
         except helpers.AuthenticationException as e:
             # log the error but don't really fail
             print 'Unable to authenticate with OIDC: %s' % e
     if not ks_token:
         if argholder.cert:
-            # try with certificate
+            # try with certificate v3
             try:
-                ks_token, tenant, last_response = helpers.get_keystone_token(argholder.endpoint,
-                                                                             argholder.cert,
-                                                                             argholder.capath,
-                                                                             argholder.timeout)
+                ks_token, tenant, last_response = helpers.get_keystone_token_x509_v3(argholder.endpoint,
+                                                                                     argholder.cert,
+                                                                                     argholder.capath,
+                                                                                     argholder.timeout)
+                tenant_id, nova_url = get_info_v3(tenant, last_response)
+            except helpers.AuthenticationException as e:
+                # no more authentication methods to try, fail here
+                print 'Unable to authenticate with VOMS + Keystone V3: %s' % e
+            # finally try with certificate v2
+            try:
+                ks_token, tenant, last_response = helpers.get_keystone_token_x509_v2(argholder.endpoint,
+                                                                                     argholder.cert,
+                                                                                     argholder.capath,
+                                                                                     argholder.timeout)
                 tenant_id, nova_url = get_info_v2(tenant, last_response)
             except helpers.AuthenticationException as e:
                 # no more authentication methods to try, fail here


### PR DESCRIPTION
This will allow us to deprecate VOMS v2 as OpenStack is also deprecating Keystone v2 API. 
The probe first tries to log with OIDC, then VOMS v3 and finally VOMS v2, should be enough to support every provider in the federation.