### PR TITLE
Version bump.

### DIFF
--- a/nagios-plugins-fedcloud.spec
+++ b/nagios-plugins-fedcloud.spec
@@ -4,7 +4,7 @@
 
 Summary: Nagios plugins for EGI FedCloud services
 Name: nagios-plugins-fedcloud
-Version: 0.3.0
+Version: 0.4.0
 Release: 1%{?dist}
 License: ASL 2.0
 Group: Network/Monitoring
@@ -42,6 +42,10 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %changelog
+* Thu Sep 5 2019 Emir Imamagic <eimamagi@srce.hr> - 0.4.0-1%{?dist}
+- Reduce default timeout for VMs to 300s
+- Clean leftover VMs
+- Do not try to use the certificate when not needed
 * Wed Apr 17 2019 Emir Imamagic <eimamagi@srce.hr> - 0.3.0-1%{?dist}
 - Add network handling
 - Delete VM to avoid leaving resources at sites


### PR DESCRIPTION
- Reduce default timeout for VMs to 300s
- Clean leftover VMs
- Do not try to use the certificate when not needed